### PR TITLE
Front/refacto rework message component

### DIFF
--- a/front/src/components/AdminExercisesList/index.js
+++ b/front/src/components/AdminExercisesList/index.js
@@ -71,8 +71,7 @@ const AdminExercisesList = ({
       <div className="admin__users">
         <h1 className="title-h2">Liste des Exercices</h1>
         {
-          messageParams.isVisible
-          && messageParams.componentToDisplayIn === 'AdminExercisesList'
+          messageParams.targetComponent === 'AdminExercisesList'
           && (
             <Message {...messageParams} />
           )
@@ -156,10 +155,7 @@ AdminExercisesList.propTypes = {
   isVisible: PropTypes.bool,
   displayMessage: PropTypes.func.isRequired,
   messageParams: PropTypes.shape({
-    type: PropTypes.string.isRequired,
-    message: PropTypes.string.isRequired,
-    componentToDisplayIn: PropTypes.string.isRequired,
-    isVisible: PropTypes.bool.isRequired,
+    targetComponent: PropTypes.string.isRequired,
   }).isRequired,
 };
 

--- a/front/src/components/AdminUsersList/index.js
+++ b/front/src/components/AdminUsersList/index.js
@@ -77,8 +77,7 @@ const AdminUsersList = ({
       <div className="admin__users">
         <h1 className="title-h2">Liste des utilisateurs</h1>
         {
-          messageParams.isVisible
-          && messageParams.componentToDisplayIn === 'AdminUsersList'
+          messageParams.targetComponent === 'AdminUsersList'
           && (
             <Message {...messageParams} />
           )
@@ -175,10 +174,7 @@ AdminUsersList.propTypes = {
   handleChangeSelect: PropTypes.func.isRequired,
   totalPages: PropTypes.number.isRequired,
   messageParams: PropTypes.shape({
-    type: PropTypes.string.isRequired,
-    componentToDisplayIn: PropTypes.string.isRequired,
-    message: PropTypes.string.isRequired,
-    isVisible: PropTypes.bool.isRequired,
+    targetComponent: PropTypes.string.isRequired,
   }).isRequired,
   displayModalConfirm: PropTypes.func.isRequired,
   displayMessage: PropTypes.func.isRequired,

--- a/front/src/components/Connection/SignInForm.js
+++ b/front/src/components/Connection/SignInForm.js
@@ -25,8 +25,7 @@ const SignInForm = ({
     <>
       <form className="header-wrapper__connection__toggle-area__form" onSubmit={handleSubmit}>
         {
-          messageParams.isVisible
-          && messageParams.componentToDisplayIn === 'SignInForm'
+          messageParams.targetComponent === 'SignInForm'
           && (
             <Message {...messageParams} />
           )
@@ -81,10 +80,7 @@ const SignInForm = ({
 SignInForm.propTypes = {
   trySignIn: PropTypes.func.isRequired,
   messageParams: PropTypes.shape({
-    type: PropTypes.string.isRequired,
-    message: PropTypes.string.isRequired,
-    componentToDisplayIn: PropTypes.string.isRequired,
-    isVisible: PropTypes.bool.isRequired,
+    targetComponent: PropTypes.string.isRequired,
   }).isRequired,
   checkEmptyField: PropTypes.func.isRequired,
   validateInput: PropTypes.func.isRequired,

--- a/front/src/components/Exercise/index.js
+++ b/front/src/components/Exercise/index.js
@@ -59,7 +59,7 @@ const Exercise = ({
         </Link>
         {
           currentQuestionIndex === 0 && (
-            messageParams.isVisible && messageParams.componentToDisplayIn === 'Exercise'
+            messageParams.targetComponent === 'Exercise'
               ? (
                 <Message {...messageParams} />
               )
@@ -177,12 +177,11 @@ Exercise.propTypes = {
   submitAnswers: PropTypes.func.isRequired,
   resetCurrentExercise: PropTypes.func.isRequired,
   messageParams: PropTypes.shape({
-    isVisible: PropTypes.bool.isRequired,
-    componentToDisplayIn: PropTypes.string.isRequired,
+    targetComponent: PropTypes.string.isRequired,
   }).isRequired,
   closeMessage: PropTypes.func.isRequired,
   isCorrected: PropTypes.bool.isRequired,
-  resultsLoading: PropTypes.bool.isRequired
+  resultsLoading: PropTypes.bool.isRequired,
 };
 
 Exercise.defaultProps = {

--- a/front/src/components/ExerciseManager/QuestionManager.js
+++ b/front/src/components/ExerciseManager/QuestionManager.js
@@ -157,8 +157,7 @@ const QuestionManager = ({
               )
           }
           {
-            messageParams.isVisible
-            && messageParams.componentToDisplayIn === `QuestionManager-q${id}`
+            messageParams.targetComponent === `QuestionManager-q${id}`
             && (
               <div className="large">
                 <Message {...messageParams} />
@@ -251,8 +250,7 @@ QuestionManager.propTypes = {
   saveOnBlur: PropTypes.func.isRequired,
   isSaved: PropTypes.bool.isRequired,
   messageParams: PropTypes.shape({
-    isVisible: PropTypes.bool.isRequired,
-    componentToDisplayIn: PropTypes.string.isRequired,
+    targetComponent: PropTypes.string.isRequired,
   }).isRequired,
   selectedFile: PropTypes.object,
   imageAlternative: PropTypes.string,

--- a/front/src/components/Message/index.js
+++ b/front/src/components/Message/index.js
@@ -1,6 +1,9 @@
 import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faTimes } from '@fortawesome/free-solid-svg-icons';
+
 import './styles.scss';
 
 const Message = ({ type, message, closeMessage }) => {
@@ -24,7 +27,10 @@ const Message = ({ type, message, closeMessage }) => {
   return (
     <div role="alert" className={`message-box ${classname}`} ref={messageContainer}>
       <p className={`message-box__content ${classname}__content`}>{message}</p>
-      <button className={`message-box__cross ${classname}__cross`} type="button" onClick={closeMessage}>x</button>
+      <button className={`message-box__cross ${classname}__cross`} type="button" onClick={closeMessage}>
+        <FontAwesomeIcon icon={faTimes} size="1x" aria-hidden="true" focusable="false" role="presentation" />
+        <span className="sr-only">Fermer le message</span>
+      </button>
     </div>
   );
 };

--- a/front/src/components/Settings/index.js
+++ b/front/src/components/Settings/index.js
@@ -71,8 +71,7 @@ const Settings = ({
       <h1 className="title-h1 center">Paramètres</h1>
       <div className="container-message-box">
         {
-          messageParams.isVisible
-          && messageParams.componentToDisplayIn === 'Settings'
+          messageParams.targetComponent === 'Settings'
           && (
             <Message {...messageParams} />
           )
@@ -270,8 +269,7 @@ Settings.propTypes = {
   comparePasswordConfirm: PropTypes.func.isRequired,
   checkEmptyField: PropTypes.func.isRequired,
   messageParams: PropTypes.shape({
-    componentToDisplayIn: PropTypes.string.isRequired,
-    isVisible: PropTypes.bool.isRequired,
+    targetComponent: PropTypes.string.isRequired,
   }).isRequired,
   displayModalConfirm: PropTypes.func.isRequired,
   modalConfirmParams: PropTypes.object.isRequired,

--- a/front/src/components/SignUp/index.js
+++ b/front/src/components/SignUp/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import Proptypes from 'prop-types';
+import PropTypes from 'prop-types';
 import picture from 'src/assets/img/contact-signup.svg';
 import Message from 'src/containers/Message';
 import CircleLoader from 'src/components/CircleLoader';
@@ -32,8 +32,7 @@ const SignUp = ({
         <img className="contact__content__illustration" src={picture} alt="" />
         <form action="" method="get" className="signup__content__form" onSubmit={handleSubmit}>
           {
-            messageParams.isVisible
-            && messageParams.componentToDisplayIn === 'SignUp'
+            messageParams.targetComponent === 'SignUp'
             && (
               <Message {...messageParams} />
             )
@@ -110,34 +109,33 @@ const SignUp = ({
 };
 
 SignUp.propTypes = {
-  email: Proptypes.shape({
-    value: Proptypes.string.isRequired,
-    controlMessage: Proptypes.string.isRequired,
+  email: PropTypes.shape({
+    value: PropTypes.string.isRequired,
+    controlMessage: PropTypes.string.isRequired,
   }).isRequired,
-  pseudo: Proptypes.shape({
-    value: Proptypes.string.isRequired,
-    controlMessage: Proptypes.string.isRequired,
+  pseudo: PropTypes.shape({
+    value: PropTypes.string.isRequired,
+    controlMessage: PropTypes.string.isRequired,
   }).isRequired,
-  password: Proptypes.shape({
-    value: Proptypes.string.isRequired,
-    controlMessage: Proptypes.string.isRequired,
+  password: PropTypes.shape({
+    value: PropTypes.string.isRequired,
+    controlMessage: PropTypes.string.isRequired,
   }).isRequired,
-  passwordConfirm: Proptypes.shape({
-    value: Proptypes.string.isRequired,
-    controlMessage: Proptypes.string.isRequired,
+  passwordConfirm: PropTypes.shape({
+    value: PropTypes.string.isRequired,
+    controlMessage: PropTypes.string.isRequired,
   }).isRequired,
-  changeField: Proptypes.func.isRequired,
-  trySignUp: Proptypes.func.isRequired,
-  loading: Proptypes.bool,
-  isSignedUp: Proptypes.bool.isRequired,
-  setControlMessage: Proptypes.func.isRequired,
-  validateEmail: Proptypes.func.isRequired,
-  testPasswordStrength: Proptypes.func.isRequired,
-  messageParams: Proptypes.shape({
-    isVisible: Proptypes.bool.isRequired,
-    componentToDisplayIn: Proptypes.string.isRequired,
+  changeField: PropTypes.func.isRequired,
+  trySignUp: PropTypes.func.isRequired,
+  loading: PropTypes.bool,
+  isSignedUp: PropTypes.bool.isRequired,
+  setControlMessage: PropTypes.func.isRequired,
+  validateEmail: PropTypes.func.isRequired,
+  testPasswordStrength: PropTypes.func.isRequired,
+  messageParams: PropTypes.shape({
+    targetComponent: PropTypes.string.isRequired,
   }).isRequired,
-  comparePasswordConfirm: Proptypes.func.isRequired,
+  comparePasswordConfirm: PropTypes.func.isRequired,
 };
 
 SignUp.defaultProps = {

--- a/front/src/middlewares/adminExercisesList.js
+++ b/front/src/middlewares/adminExercisesList.js
@@ -38,7 +38,7 @@ export default (store) => (next) => async (action) => {
         store.dispatch(setMessage({
           type: 'confirm',
           message: `L'exercice #${action.idExercise} a bien été supprimé.`,
-          componentToDisplayIn: 'AdminExercisesList',
+          targetComponent: 'AdminExercisesList',
         }));
       }
       catch (err) {
@@ -46,7 +46,7 @@ export default (store) => (next) => async (action) => {
         store.dispatch(setMessage({
           type: 'error',
           message: 'Une erreur est survenue lors de la suppression.',
-          componentToDisplayIn: 'AdminExercisesList',
+          targetComponent: 'AdminExercisesList',
         }));
       }
       finally {

--- a/front/src/middlewares/auth.js
+++ b/front/src/middlewares/auth.js
@@ -47,7 +47,7 @@ export default (store) => (next) => async (action) => {
           store.dispatch(setMessage({
             type: 'error',
             message: 'L\'adresse e-mail ou le mot de passe n\'est pas valide.',
-            componentToDisplayIn: 'SignInForm',
+            targetComponent: 'SignInForm',
           }));
         }
       }
@@ -127,7 +127,7 @@ export default (store) => (next) => async (action) => {
         store.dispatch(setMessage({
           type: 'confirm',
           message: 'Votre pseudo a bien été modifié.',
-          componentToDisplayIn: 'Settings',
+          targetComponent: 'Settings',
         }));
 
         store.dispatch(setInfoUser('pseudo', response.data.pseudo));
@@ -137,7 +137,7 @@ export default (store) => (next) => async (action) => {
         store.dispatch(setMessage({
           type: 'error',
           message: 'Une erreur est survenue lors de la modification de votre pseudo.',
-          componentToDisplayIn: 'Settings',
+          targetComponent: 'Settings',
         }));
       }
       return next(action);
@@ -155,7 +155,7 @@ export default (store) => (next) => async (action) => {
         store.dispatch(setMessage({
           type: 'confirm',
           message: 'Votre adresse e-mail a bien été modifiée.',
-          componentToDisplayIn: 'Settings',
+          targetComponent: 'Settings',
         }));
         store.dispatch(setInfoUser('email', response.data.email));
       }
@@ -164,7 +164,7 @@ export default (store) => (next) => async (action) => {
         store.dispatch(setMessage({
           type: 'error',
           message: 'Une erreur est survenue lors de la modification de votre adresse e-mail.',
-          componentToDisplayIn: 'Settings',
+          targetComponent: 'Settings',
         }));
       }
       return next(action);
@@ -182,7 +182,7 @@ export default (store) => (next) => async (action) => {
         store.dispatch(setMessage({
           type: 'confirm',
           message: 'Votre mot de passe a bien été modifié.',
-          componentToDisplayIn: 'Settings',
+          targetComponent: 'Settings',
         }));
       }
       catch (err) {
@@ -190,7 +190,7 @@ export default (store) => (next) => async (action) => {
         store.dispatch(setMessage({
           type: 'error',
           message: 'Une erreur est survenue lors de la modification de votre mot de passe.',
-          componentToDisplayIn: 'Settings',
+          targetComponent: 'Settings',
         }));
       }
       return next(action);
@@ -213,7 +213,7 @@ export default (store) => (next) => async (action) => {
         store.dispatch(setMessage({
           type: 'confirm',
           message: 'Votre image a bien été modifiée.',
-          componentToDisplayIn: 'Settings',
+          targetComponent: 'Settings',
         }));
         store.dispatch(setInfoUser('picturePath', pathPicture.substring(6)));
         store.dispatch(setSelectedFile(null));
@@ -223,7 +223,7 @@ export default (store) => (next) => async (action) => {
         store.dispatch(setMessage({
           type: 'error',
           message: 'Une erreur est survenue lors de la modification de votre image.',
-          componentToDisplayIn: 'Settings',
+          targetComponent: 'Settings',
         }));
       }
       return next(action);

--- a/front/src/middlewares/exerciseManager/questionManager.js
+++ b/front/src/middlewares/exerciseManager/questionManager.js
@@ -157,7 +157,7 @@ export default (store) => (next) => async (action) => {
         store.dispatch(setMessage({
           type: 'confirm',
           message: 'L\'image a bien été associée à cette question',
-          componentToDisplayIn: `QuestionManager-q${action.questionId}`,
+          targetComponent: `QuestionManager-q${action.questionId}`,
         }));
         store.dispatch(setExerciseManagerIsSaved(true));
       }
@@ -166,7 +166,7 @@ export default (store) => (next) => async (action) => {
         store.dispatch(setMessage({
           type: 'error',
           message: 'L\'image n\'a pas pu être chargée sur le serveur',
-          componentToDisplayIn: `QuestionManager-q${action.questionId}`,
+          targetComponent: `QuestionManager-q${action.questionId}`,
         }));
       }
       finally {

--- a/front/src/middlewares/exercises.js
+++ b/front/src/middlewares/exercises.js
@@ -132,7 +132,7 @@ export default (store) => (next) => async (action) => {
         store.dispatch(setMessage({
           type: data.scoreResult >= 50 ? 'confirm' : 'error',
           message: resultMessage,
-          componentToDisplayIn: 'Exercise',
+          targetComponent: 'Exercise',
         }));
       }
       catch (err) {

--- a/front/src/middlewares/signup.js
+++ b/front/src/middlewares/signup.js
@@ -32,7 +32,7 @@ export default (store) => (next) => async (action) => {
         store.dispatch(setMessage({
           type: 'confirm',
           message: `Votre compte a bien été créé avec l'adresse ${email.value}. Vous pouvez vous connecter dès à présent`,
-          componentToDisplayIn: 'SignUp',
+          targetComponent: 'SignUp',
         }));
         store.dispatch(signUp());
       }
@@ -41,7 +41,7 @@ export default (store) => (next) => async (action) => {
           store.dispatch(setMessage({
             type: 'error',
             message: `L'adresse e-mail est déjà utilisée`,
-            componentToDisplayIn: 'SignUp',
+            targetComponent: 'SignUp',
           }));
         }
       }

--- a/front/src/middlewares/users.js
+++ b/front/src/middlewares/users.js
@@ -44,7 +44,7 @@ export default (store) => (next) => async (action) => {
         store.dispatch(setMessage({
           type: 'confirm',
           message: `L'utilisateur #${action.idUser} a bien été supprimé.`,
-          componentToDisplayIn: 'AdminUsersList',
+          targetComponent: 'AdminUsersList',
         }));
       }
       catch (err) {
@@ -52,7 +52,7 @@ export default (store) => (next) => async (action) => {
         store.dispatch(setMessage({
           type: 'error',
           message: 'Une erreur est survenue lors de la suppression de l\'utilisateur',
-          componentToDisplayIn: 'AdminUsersList',
+          targetComponent: 'AdminUsersList',
         }));
       }
       finally {
@@ -71,7 +71,7 @@ export default (store) => (next) => async (action) => {
         store.dispatch(setMessage({
           type: 'confirm',
           message: `Le rôle de l'utilisateur #${action.idUser} a bien été modifié.`,
-          componentToDisplayIn: 'AdminUsersList',
+          targetComponent: 'AdminUsersList',
         }));
         store.dispatch(setUsers(action.idUser, responsibility));
       }
@@ -80,7 +80,7 @@ export default (store) => (next) => async (action) => {
         store.dispatch(setMessage({
           type: 'error',
           message: 'Une erreur est survenue lors de la modification de l\'utilisateur',
-          componentToDisplayIn: 'AdminUsersList',
+          targetComponent: 'AdminUsersList',
         }));
       }
       finally {

--- a/front/src/reducers/other.js
+++ b/front/src/reducers/other.js
@@ -6,8 +6,8 @@ import {
   SET_MESSAGE,
   UNSET_MESSAGE,
   SET_APP_LOADING,
+  SET_MOBILE_MENU_VISIBILITY,
 } from 'src/actions/other';
-import { SET_MOBILE_MENU_VISIBILITY } from '../actions/other';
 
 const initialState = {
   mobileMenuVisibility: false,
@@ -32,8 +32,7 @@ const initialState = {
   messageParams: {
     type: '',
     message: '',
-    componentToDisplayIn: '',
-    isVisible: false,
+    targetComponent: '',
   },
 };
 
@@ -49,7 +48,6 @@ const other = (state = initialState, action = {}) => {
         ...state,
         messageParams: {
           ...action.messageParams,
-          isVisible: true,
         },
       };
     case UNSET_MESSAGE:


### PR DESCRIPTION
Simplification du composant Message :

- ajout d'une icône pour le bouton de fermeture avec un texte alternative sr-only pour l'access.
- renommage de la propriété "componentToDisplayIn" => "targetComponent". Il s'agit d'une string qui correspond au nom du composant dans lequel on veut que le message s'affiche. Par défaut, la chaîne de caractère est vide.
- suppression de la propriété "isVisible". Cette propriété était redondante et ajoutait un test inutile partout où le composant message était utilisé (on vérifiait à la fois que isVisible était à true, et que targetComponent avait une valeur qui correspondait au composant actuel). Il suffit de verifier si targetComponent === le nom du composant actuel. Si c'est le cas, on affiche le message, sinon (si targetComponent est vide ou s'il contient le nom d'un autre composant), on affiche pas.